### PR TITLE
Make tls secret required for instance reconcile

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ type CodeServerSpec struct {
 	ReadinessProbe *v1.Probe `json:"readinessProbe,omitempty" protobuf:"bytes,19,opt,name=readinessProbe"`
 	// Specifies the terminal container port for connection, defaults in 8080.
 	ContainerPort string `json:"containerPort,omitempty" protobuf:"bytes,20,opt,name=containerPort"`
+    // Specifies the connectionString for frontend to connect, MUST within to string placeholder for subdomain and
+    // hostname, for example https://%s.%s/terminal or wss://%s.%s/ws, NOTE, tls MUST be enabled
+    ConnectionString string `json:"connectionString,omitempty" protobuf:"bytes,21,opt,name=connectionString"`
 }
 ```
 ## Gotty based web terminal

--- a/api/v1alpha1/codeserver_types.go
+++ b/api/v1alpha1/codeserver_types.go
@@ -87,6 +87,9 @@ type CodeServerSpec struct {
 	ReadinessProbe *v1.Probe `json:"readinessProbe,omitempty" protobuf:"bytes,19,opt,name=readinessProbe"`
 	// Specifies the terminal container port for connection, defaults in 8080.
 	ContainerPort string `json:"containerPort,omitempty" protobuf:"bytes,20,opt,name=containerPort"`
+	// Specifies the connectionString for frontend to connect, MUST within to string placeholder for subdomain and
+	// hostname, for example https://%s.%s/terminal or wss://%s.%s/ws, NOTE, tls MUST be enabled
+	ConnectionString string `json:"connectionString,omitempty" protobuf:"bytes,21,opt,name=connectionString"`
 }
 
 // ServerConditionType describes the type of state of code server condition

--- a/config/crd/bases/cs.opensourceways.com_codeservers.yaml
+++ b/config/crd/bases/cs.opensourceways.com_codeservers.yaml
@@ -51,6 +51,12 @@ spec:
                   Only http path are supported and time should be in the format of
                   2006-01-02T15:04:05.000Z.
                 type: string
+              connectionString:
+                description: Specifies the connectionString for frontend to connect,
+                  MUST within to string placeholder for subdomain and hostname, for
+                  example https://%s.%s/terminal or wss://%s.%s/ws, NOTE, tls MUST
+                  be enabled
+                type: string
               containerPort:
                 description: Specifies the terminal container port for connection,
                   defaults in 8080.

--- a/controllers/codeserver_watcher.go
+++ b/controllers/codeserver_watcher.go
@@ -61,10 +61,11 @@ func (cs *CodeServerWatcher) inActiveCodeServer(req types.NamespacedName) {
 	if !HasCondition(codeServer.Status, csv1alpha1.ServerInactive) && !HasCondition(codeServer.Status, csv1alpha1.ServerRecycled) {
 		inactiveCondition := NewStateCondition(csv1alpha1.ServerInactive,
 			"code server has been marked inactive", map[string]string{}, corev1.ConditionTrue)
-		SetCondition(&codeServer.Status, inactiveCondition)
-		err := cs.Client.Update(context.TODO(), codeServer)
-		if err != nil {
-			reqLogger.Error(err, "Failed to update code server status.")
+		if SetCondition(&codeServer.Status, inactiveCondition) {
+			err := cs.Client.Update(context.TODO(), codeServer)
+			if err != nil {
+				reqLogger.Error(err, "Failed to update code server status.")
+			}
 		}
 	}
 }
@@ -82,10 +83,11 @@ func (cs *CodeServerWatcher) recycleCodeServer(req types.NamespacedName) {
 	if !HasCondition(codeServer.Status, csv1alpha1.ServerRecycled) {
 		recycleCondition := NewStateCondition(csv1alpha1.ServerRecycled,
 			"code server has been marked recycled", map[string]string{}, corev1.ConditionTrue)
-		SetCondition(&codeServer.Status, recycleCondition)
-		err := cs.Client.Update(context.TODO(), codeServer)
-		if err != nil {
-			reqLogger.Error(err, "Failed to update code server status.")
+		if SetCondition(&codeServer.Status, recycleCondition) {
+			err := cs.Client.Update(context.TODO(), codeServer)
+			if err != nil {
+				reqLogger.Error(err, "Failed to update code server status.")
+			}
 		}
 	}
 }

--- a/example/sample_aim.yaml
+++ b/example/sample_aim.yaml
@@ -29,10 +29,4 @@ spec:
       cd /workspace/content
       pip install -r requirements.txt
       exec python3 launch.py
-  initPlugins:
-    obs-clone:
-      - --source=xihe-obj/models/wesley/lenet_mnist/
-      - --obs-ak=<ak>
-      - --obs-sk=<sk>
-      - --obs-bucketname=obs-xihe-beijing4-test
-      - --obs-endpoint=obs.cn-north-4.myhuaweicloud.com
+  connectionString: "https://%s.%s/"

--- a/example/sample_gotty.yaml
+++ b/example/sample_gotty.yaml
@@ -4,7 +4,7 @@ metadata:
   name: codeserver-gotty
   namespace: default
 spec:
-  runtime: gotty
+  runtime: generic
   subdomain: codeservergotty
   image: "opensourceway/openeuler-20.03-lts-sp2-base:latest@sha256:87d1b8918ea690badf55349a63b4766f720f9297dff72ff7965f93b7b02ef5a5"
   storageSize: "1Gi"
@@ -50,3 +50,4 @@ spec:
     limits:
       cpu: 500m
       memory: 500Mi
+  connectionString: "wss://%s.%s/ws"

--- a/example/sample_gradio.yaml
+++ b/example/sample_gradio.yaml
@@ -29,3 +29,4 @@ spec:
       cd /workspace/content
       pip install -r requirements.txt
       exec python3 launch.py
+  connectionString: "https://%s.%s/"

--- a/example/sample_pgweb.yaml
+++ b/example/sample_pgweb.yaml
@@ -25,3 +25,4 @@ spec:
     requests:
       cpu: "500m"
       memory: "500Mi"
+  connectionString: "https://%s.%s/"


### PR DESCRIPTION
1. add `ConnectionString` for generic runtime to let user to specify the connection string format
2. make tls secret required when reconciling instances
3. remove unnecessary updates